### PR TITLE
Add debian dependencies (supersedes  #10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,31 @@ Building the whole client depends on recent versions of
 
 Here are the instructions for some OSes:
 
-* On macOS, do `brew install glib cairo pango gdk-pixbuf gtk+3 atk gnome-icon-theme pkg-config`
+* On macOS, do
+```
+brew install \
+    glib \
+    cairo \
+    pango \
+    gdk-pixbuf \
+    gtk+3 \
+    atk \
+    gnome-icon-theme \
+    pkg-config
+```
+
+* On debian, do
+```
+sudo apt-get install -y \
+    gcc \
+    clang \
+    libcairo2-dev \
+    libssl-dev \
+    libdbus-1-dev \
+    libgdk3.0-cil-dev \
+    libgtk-3-dev \
+    libsqlite3-dev
+```
 
 On startup a configuration file `coax.toml` is written to
 `$HOME/.config/coax/`.


### PR DESCRIPTION
Sadly not well tested because I could not get it building I removed some packages from #10 that were not found on my debian 10 system.

```
error: failed to run custom build command for `openssl-sys v0.9.19`
process didn't exit successfully: `/home/chiller/Desktop/git/coax/target/debug/build/openssl-sys-e315f35f95e57410/build-script-build` (exit code: 101)
--- stdout
cargo:rerun-if-env-changed=X86_64_UNKNOWN_LINUX_GNU_OPENSSL_LIB_DIR
cargo:rerun-if-env-changed=OPENSSL_LIB_DIR
cargo:rerun-if-env-changed=X86_64_UNKNOWN_LINUX_GNU_OPENSSL_INCLUDE_DIR
cargo:rerun-if-env-changed=OPENSSL_INCLUDE_DIR
cargo:rerun-if-env-changed=X86_64_UNKNOWN_LINUX_GNU_OPENSSL_DIR
cargo:rerun-if-env-changed=OPENSSL_DIR
cargo:rustc-link-lib=ssl
cargo:rustc-link-lib=crypto
OPT_LEVEL = Some("0")
TARGET = Some("x86_64-unknown-linux-gnu")
HOST = Some("x86_64-unknown-linux-gnu")
TARGET = Some("x86_64-unknown-linux-gnu")
TARGET = Some("x86_64-unknown-linux-gnu")
HOST = Some("x86_64-unknown-linux-gnu")
CC_x86_64-unknown-linux-gnu = None
CC_x86_64_unknown_linux_gnu = None
HOST_CC = None
CC = None
HOST = Some("x86_64-unknown-linux-gnu")
TARGET = Some("x86_64-unknown-linux-gnu")
HOST = Some("x86_64-unknown-linux-gnu")
CFLAGS_x86_64-unknown-linux-gnu = None
CFLAGS_x86_64_unknown_linux_gnu = None
HOST_CFLAGS = None
CFLAGS = None
DEBUG = Some("true")
running: "cc" "-O0" "-ffunction-sections" "-fdata-sections" "-fPIC" "-g" "-m64" "-Wall" "-Wextra" "-E" "/home/chiller/Desktop/git/coax/target/debug/build/openssl-sys-bcca8feb4c4a61dc/out/expando.c"
exit code: 0
cargo:rustc-cfg=osslconf="OPENSSL_NO_SSL3_METHOD"
cargo:conf=OPENSSL_NO_SSL3_METHOD

--- stderr
thread 'main' panicked at '

This crate is only compatible with OpenSSL 1.0.1, 1.0.2, and 1.1.0, or LibreSSL
2.5 and 2.6.0, but a different version of OpenSSL was found. The build is now
aborting due to this version mismatch.

', /home/chiller/.cargo/registry/src/github.com-1ecc6299db9ec823/openssl-sys-0.9.19/build.rs:488:9
note: Run with `RUST_BACKTRACE=1` for a backtrace.

warning: build failed, waiting for other jobs to finish...
error: build failed
```
